### PR TITLE
Add 'host' option to npm scripts, binds to 0.0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "host": "HOST=0.0.0.0 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
To run, you can do `npm run host`.

Then, you should have access to the server from bound ips -- to find some, you can use `ifconfig | grep inet`